### PR TITLE
Do not append bookmark if it's a class/interface.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -120,7 +120,7 @@ module.exports = {
         var dest = this.findParent(ref, ['namespace', 'class', 'struct', 'interface']);
         if (!dest || compound.refid == dest.refid)
           return '#' + id;
-        return this.compoundPath(dest, options) + '#' + id;
+        return this.compoundPath(dest, options);
       } else {
         if (compound.kind == 'page')
           return this.compoundPath(compound.parent, options) + '#' + id;


### PR DESCRIPTION
The bookmarks (e.g. ICoreWebView2.md#icorewebview2) don't exist in such classes.