### PR TITLE
Add support for .NET documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = {
         'define',
         'enum',
         // 'enumvalue',
+        'event',
         'func',
         // 'variable',
         'property',

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -118,8 +118,13 @@ module.exports = {
         return this.compoundPath(ref, options) + '#' + id;
       } else if (options.classes) {
         var dest = this.findParent(ref, ['namespace', 'class', 'struct', 'interface']);
-        if (!dest || compound.refid == dest.refid)
+        if (!dest || compound.refid == dest.refid) {
+          // Not sure why icorewebview2environment is not covered
+          if (id.startsWith('icorewebview2') && id.endsWith('environment')) {
+            return '';
+          }
           return '#' + id;
+        }
         return this.compoundPath(dest, options);
       } else {
         if (compound.kind == 'page')
@@ -142,9 +147,12 @@ module.exports = {
   },
 
   writeCompound: function(compound, contents, references, options) {
-    this.writeFile(this.compoundPath(compound, options), contents.map(function(content) {
-      return this.resolveRefs(content, compound, references, options);
-    }.bind(this)));
+    // Not generating markdown files for namespaces
+    if (compound.kind !== 'namespace' || compound.name === "Microsoft.Web.WebView2.Core") {
+      this.writeFile(this.compoundPath(compound, options), contents.map(function(content) {
+        return this.resolveRefs(content, compound, references, options);
+      }.bind(this)));
+    } 
   },
 
   // Write the output file

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -137,6 +137,8 @@ module.exports = {
   compoundPath: function(compound, options) {
     if (compound.kind == 'page') {
       return path.dirname(options.output) + "/page-" + compound.name + ".md";
+    } else if (compound.kind == 'namespace') {
+      return path.dirname(options.output) + "/namespace-" + compound.name + ".md";
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -138,11 +138,11 @@ module.exports = {
     if (compound.kind == 'page') {
       return path.dirname(options.output) + "/page-" + compound.name + ".md";
     } else if (compound.kind == 'namespace') {
-      return path.dirname(options.output) + "/namespace-" + compound.name + ".md";
+      return path.dirname(options.output) + "/namespace-" + compound.name.replace(/\./g, '-').toLowerCase() + ".md";
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name.replace(/\:/g, '-'));
+      return util.format(options.output, compound.name.replace(/\:/g, '-').replace(/\./g, '-').toLowerCase());
     } else {
       return options.output;
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -319,6 +319,14 @@ module.exports = {
         m = m.concat(markdown.refLink(member.name, member.refid));
         break;
 
+      case 'event':
+        // Add prot
+        m = m.concat(memberdef.$.prot, ' '); // public, private, ...
+        m = m.concat(toMarkdown(memberdef.type), ' ');
+        // m = m.concat(memberdef.name[0]._);
+        m = m.concat(markdown.refLink(member.name, member.refid));
+        break;
+        
       case 'property':
         // Do not append {property} for properties
         // m = m.concat(['{', member.kind, '} ']);

--- a/src/parser.js
+++ b/src/parser.js
@@ -44,7 +44,12 @@ function toMarkdown(element, context) {
           case '__text__':
             // Append 'event ' if EventHandler 
             s = s.concat(element._.startsWith('EventHandler') ? 'event ' : []);
-            s = s.concat(element._);
+            // Remove question mark
+            if (element._.startsWith('bool?') || element._.startsWith('CoreWebView2?') || element._.startsWith('Uri?')) {
+              s = s.concat(element._.replace(/[?]+/g, ''));
+            } else {
+              s = s.concat(element._);
+            }
             break;
           case 'emphasis': s = '*'; break;
           case 'bold': s = '**'; break;
@@ -289,7 +294,8 @@ module.exports = {
         // m = m.concat(memberdef.$.inline == 'yes' ? ['inline', ' '] : []);
         m = m.concat(memberdef.$.static == 'yes' ? ['static', ' '] : []);
         m = m.concat(memberdef.$.virt == 'virtual' ? ['virtual', ' '] : []);
-        m = m.concat(toMarkdown(memberdef.type), ' ');
+        // Fixed extra space for constructor
+        m = m.concat(toMarkdown(memberdef.type) == '' ? [toMarkdown(memberdef.type), ' '] : []);
         m = m.concat(memberdef.$.explicit  == 'yes' ? ['explicit', ' '] : []);
         // m = m.concat(memberdef.name[0]._);
         m = m.concat(markdown.refLink(member.name, member.refid));

--- a/src/parser.js
+++ b/src/parser.js
@@ -86,7 +86,7 @@ function toMarkdown(element, context) {
               s = '\n##### Returns\n'
             }
             else if (element.$.kind == 'see') {
-              s = '**See also**: '
+              s = '\n**See also**: '
             }
             else {
               console.assert(element.$.kind + ' not supported.');
@@ -303,6 +303,11 @@ module.exports = {
         m = m.concat(memberdef.argsstring[0]._.match(/noexcept$/) ? ' noexcept' : '');
         m = m.concat(memberdef.argsstring[0]._.match(/=\s*delete$/) ? ' = delete' : '');
         m = m.concat(memberdef.argsstring[0]._.match(/=\s*default/) ? ' = default' : '');
+        if (memberdef.$.static == 'yes') {
+          m.forEach(element => {
+           console.log(element); 
+          });
+        }
         break;
 
       case 'variable':

--- a/src/parser.js
+++ b/src/parser.js
@@ -255,6 +255,11 @@ module.exports = {
   parseMember: function (member, section, memberdef) {
     if (member.kind == 'typedef' && toMarkdown(memberdef.type).startsWith('enum'))
       return;
+  
+    // Hide private members
+    if (memberdef.$.prot == 'private')
+      return;
+
     log.verbose('Processing member ' + member.kind + ' ' + member.name);
     member.section = section;
     copy(member, 'briefdescription', memberdef);

--- a/src/parser.js
+++ b/src/parser.js
@@ -52,10 +52,10 @@ function toMarkdown(element, context) {
           case 'computeroutput': s = '`'; break;
           case 'parameterlist':
             if (element.$.kind == 'exception') {
-              s = '\n#### Exceptions\n'
+              s = '\n##### Exceptions\n'
             }
             else {
-              s = '\n#### Parameters\n'
+              s = '\n##### Parameters\n'
             }
             break;
 
@@ -83,7 +83,7 @@ function toMarkdown(element, context) {
               s = '> ';
             }
             else if (element.$.kind == 'return') {
-              s = '\n#### Returns\n'
+              s = '\n##### Returns\n'
             }
             else if (element.$.kind == 'see') {
               s = '**See also**: '

--- a/src/parser.js
+++ b/src/parser.js
@@ -256,8 +256,8 @@ module.exports = {
     if (member.kind == 'typedef' && toMarkdown(memberdef.type).startsWith('enum'))
       return;
   
-    // Hide private members
-    if (memberdef.$.prot == 'private')
+    // Hide protected and private members
+    if (memberdef.$.prot == 'protected' || memberdef.$.prot == 'private')
       return;
 
     log.verbose('Processing member ' + member.kind + ' ' + member.name);


### PR DESCRIPTION
- Handle implicit anchors for `ICoreWebView2*Environment`
- Only generate namespace page for `Microsoft.Web.WebView2.Core`
- Use language label information from filename in programlisting while generating markdown
- For methods/functions:
  - Not add `inline`
  - Separate arguments with whitespaces
  - Add one more `#` for Exceptions, Parameters, and Returns
- For properties:
  - Not add `{property}`
  - Add access modifiers (e.g. `public` and `protected`)
  - Add `event` keyword
- Added support for event
- Hid private members (somehow it's not caught by doxygen even with `EXTRACT_PRIVATE` set to `NO`)
- Use C# style namespace format (`.` instead of `::`)
  - Used `-` in the filename for namespaces because no other punctuations are allowed filenames in MSDN
  - Prefixed the namespace files with `namespace-`