### PR TITLE
Formatting improvements

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -135,7 +135,7 @@ module.exports = {
     } else if (options.groups) {
       return util.format(options.output, compound.groupname);
     } else if (options.classes) {
-      return util.format(options.output, compound.name.replace(/\:/g, '-'));
+      return util.format(options.output, compound.name.replace(/\:/g, '-').replace(/\./g, '-').toLowerCase());
     } else {
       return options.output;
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -56,7 +56,13 @@ function toMarkdown(element, context) {
             break;
 
           case 'parameteritem': s = '* '; break;
-          case 'programlisting': s = '\n```cpp\n'; break;
+          case 'programlisting':
+            // Get the language information from filename
+            var lang = '';
+            if (typeof(element.$) !== 'undefined')
+              lang = element.$.filename.substring(element.$.filename.lastIndexOf('.') + 1);
+            s = '\n```' + lang + '\n';
+            break;
           case 'orderedlist':
             context.push(element);
             s = '\n\n';
@@ -280,7 +286,8 @@ module.exports = {
         m = m.concat('(');
         if (memberdef.param) {
           memberdef.param.forEach(function (param, argn) {
-            m = m.concat(argn == 0 ? [] : ',');
+            // Add space between arguments
+            m = m.concat(argn == 0 ? [] : ', ');
             m = m.concat([toMarkdown(param.type)]);
             m = m.concat(param.declname ? [' ', toMarkdown(param.declname)] : []);
           });


### PR DESCRIPTION
- Make all filename lowercase to [follow guidance for friendly filenames](https://review.docs.microsoft.com/en-us/help/onboard/seo-checklist?branch=main#follow-guidance-for-friendly-filenames)
- Use code snippets file extension for programlisting. For instance, use `` ```html `` for `sample.html` instead of always producing `` ```cpp ``
- Not add backticks around markdown links or urls such as `` `[ICoreWebView2](icorewebview2.md)` `` or `` `[bing.com](bing.com)` ``